### PR TITLE
Zero size user conversion PDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ To record web3 user actions on-chain using cNFTs and instantly reward publishers
 ## Accounts (State)
 
 - **Campaign**: Outlines targeted audiences, available offers, and the value of each offer.
-- **UserConversion**: A Program Derived Address (PDA) created when a user claims an offer to prevent duplicate claims by the same user.
 - **Faucet**: An account with authority over a merkle tree to enable the minting of cNFTs.
 
 ## Instructions

--- a/programs/onnyx_advertise/src/instructions/campaign_ixs/crank.rs
+++ b/programs/onnyx_advertise/src/instructions/campaign_ixs/crank.rs
@@ -1,8 +1,31 @@
 use mpl_bubblegum::{instructions::{MintV1CpiBuilder}, types::{Creator, MetadataArgs, TokenProgramVersion, TokenStandard}};
+use anchor_lang::system_program::{create_account, CreateAccount};
 
 use crate::*;
 
 pub fn crank(ctx: Context<CrankCampaign>, params: CrankCampaignParams) -> Result<()> {
+
+    // Uniqueness check - init user_conversion PDA as program owned acc
+    let rent = Rent::get()?;
+    create_account(
+        CpiContext::new_with_signer(
+            ctx.accounts.system_program.to_account_info(),
+            CreateAccount {
+                from: ctx.accounts.onnyx.to_account_info(),
+                to: ctx.accounts.user_conversion.to_account_info()
+            },
+            &[&[
+                ctx.accounts.campaign.key().as_ref(),
+                ctx.accounts.user_dkp.key.as_ref(),
+                params.offer_name.as_bytes(),
+                &[ctx.bumps.user_conversion]
+            ]]
+        ),
+        rent.minimum_balance(0),
+        0,
+        &ID
+    )?;
+
     // TODO add requirement for onnyx keypair to be a signer
     // update campaign data
     let price = Campaign::log_completed_offer(&mut ctx.accounts.campaign, params.offer_name.clone(), params.audiance.clone()).unwrap();
@@ -87,14 +110,13 @@ pub struct CrankCampaign<'info> {
     pub faucet: Account<'info, Faucet>,
     #[account(mut)]
     pub campaign: Account<'info, Campaign>,
+    /// Must be a system program account. If not means initialized as this program account = second claim (uniqueness check fail)
     #[account(
-        init,
-        space=UserConversion::LEN,
-        payer = onnyx,
+        mut,
         seeds=[campaign.key().as_ref(), user_dkp.key().as_ref(), params.offer_name.as_bytes()],
         bump
     )]
-    pub user_conversion: Account<'info, UserConversion>,
+    pub user_conversion: SystemAccount<'info>,
     /// CHECK: to be paid out to, verification that this is the correct account happens in our backend
     #[account(mut)]
     pub publisher: UncheckedAccount<'info>,

--- a/programs/onnyx_advertise/src/instructions/campaign_ixs/crank.rs
+++ b/programs/onnyx_advertise/src/instructions/campaign_ixs/crank.rs
@@ -6,7 +6,6 @@ use crate::*;
 pub fn crank(ctx: Context<CrankCampaign>, params: CrankCampaignParams) -> Result<()> {
 
     // Uniqueness check - init user_conversion PDA as program owned acc
-    let rent = Rent::get()?;
     create_account(
         CpiContext::new_with_signer(
             ctx.accounts.system_program.to_account_info(),
@@ -21,7 +20,7 @@ pub fn crank(ctx: Context<CrankCampaign>, params: CrankCampaignParams) -> Result
                 &[ctx.bumps.user_conversion]
             ]]
         ),
-        rent.minimum_balance(0),
+        Rent::get()?.minimum_balance(0),
         0,
         &ID
     )?;

--- a/programs/onnyx_advertise/src/state/mod.rs
+++ b/programs/onnyx_advertise/src/state/mod.rs
@@ -2,5 +2,3 @@ pub mod campaign;
 pub use campaign::*;
 pub mod faucet;
 pub use faucet::*;
-pub mod user_conversion;
-pub use user_conversion::*;

--- a/programs/onnyx_advertise/src/state/user_conversion.rs
+++ b/programs/onnyx_advertise/src/state/user_conversion.rs
@@ -1,8 +1,0 @@
-use crate::*;
-
-#[account]
-pub struct UserConversion {}
-
-impl UserConversion {
-    pub const LEN: usize = 8;
-}


### PR DESCRIPTION
Since UserConversion doesn't hold any data and used only as a uniqueness check, I don't see a reason to define a separate anchor account struct for it.

Now there is no need to hold anchor discriminator, so account could have 0 bytes instead of 8 data.
0-bytes account rent exemption is `890880` lamports instead of `946560` for 8 bytes.
That saves `55680` lamports.

On a scale and also considering this is cNFT-based project (while most of cNFT related is meant to reduce costs), that might be a good economy.